### PR TITLE
Split Audit module to make injection cleaner

### DIFF
--- a/src/main/scala/Main.scala
+++ b/src/main/scala/Main.scala
@@ -13,8 +13,11 @@ import scala.concurrent.duration._
 object Main extends App {
 
   implicit val config: SystemModule =
-    new SystemModule with StandardCountingModule 
-    with StandardAuditModule with AkkaConfigModule {}
+    new SystemModule
+      with StandardCountingModule
+      with StandardAuditBusModule
+      with StandardAuditCompanionModule
+      with AkkaConfigModule {}
 
   // this could be called inside a supervisor actor to create a supervisor hierarchy
   val counter = config.countingActor

--- a/src/main/scala/sample/Audit.scala
+++ b/src/main/scala/sample/Audit.scala
@@ -21,14 +21,14 @@ class AuditBus extends Actor {
 
 object AuditCompanion {
   val name = "AuditCompanion"
-  def props(implicit auditModule: AuditModule) = Props(new AuditCompanion)
+  def props(implicit auditBusModule: AuditBusModule) = Props(new AuditCompanion)
 }
 
 
-class AuditCompanion(implicit auditModule: AuditModule) extends Actor {
+class AuditCompanion(implicit auditBusModule: AuditBusModule) extends Actor {
   val created = System.currentTimeMillis
 
-  val auditBus = auditModule.auditBus
+  val auditBus = auditBusModule.auditBus
   def receive = {
     case msg => auditBus forward AuditBus.AuditEvent(created, msg)
   }

--- a/src/main/scala/sample/AuditModule.scala
+++ b/src/main/scala/sample/AuditModule.scala
@@ -3,12 +3,18 @@ package sample
 import akka.actor.ActorRef
 import config.ConfigModule
 
-trait AuditModule {
+trait AuditCompanionModule {
   def auditCompanion: ActorRef
+}
+
+trait AuditBusModule {
   def auditBus: ActorRef
 }
 
-trait StandardAuditModule extends AuditModule { this: ConfigModule =>
-  lazy val auditCompanion: ActorRef = actorSystem.actorOf(AuditCompanion.props(this), AuditCompanion.name)
+trait StandardAuditBusModule extends AuditBusModule{ this: ConfigModule =>
   lazy val auditBus: ActorRef = actorSystem.actorOf(AuditBus.props, AuditBus.name)
+}
+
+trait StandardAuditCompanionModule extends AuditCompanionModule{ this: ConfigModule with AuditBusModule =>
+  lazy val auditCompanion: ActorRef = actorSystem.actorOf(AuditCompanion.props(this), AuditCompanion.name)
 }

--- a/src/main/scala/sample/SystemModule.scala
+++ b/src/main/scala/sample/SystemModule.scala
@@ -1,8 +1,9 @@
 package sample
 
 import config.ConfigModule
+import sample.{AuditCompanionModule, AuditBusModule, CountingModule}
 
 /**
  * Created by dick on 12/8/14.
  */
-trait SystemModule extends CountingModule with AuditModule with ConfigModule
+trait SystemModule extends CountingModule with AuditBusModule with AuditCompanionModule with ConfigModule

--- a/src/test/scala/sample/CountingActorSpec.scala
+++ b/src/test/scala/sample/CountingActorSpec.scala
@@ -11,8 +11,8 @@ import scala.concurrent.Await
 import scala.concurrent.duration._
 
 class CountingActorSpec(_system: ActorSystem) extends TestKit(_system)
-    with ImplicitSender with WordSpecLike with OneInstancePerTest
-    with Matchers with BeforeAndAfterAll {
+with ImplicitSender with WordSpecLike with OneInstancePerTest
+with Matchers with BeforeAndAfterAll {
 
   def this() = this(ActorSystem("CountingActorSpec"))
 
@@ -23,8 +23,9 @@ class CountingActorSpec(_system: ActorSystem) extends TestKit(_system)
   "a Parfait-managed count actor" must {
     "send the correct count to its counting service" in {
       val testConfig: SystemModule =
-        new SystemModule with StandardCountingModule 
-            with StandardAuditModule with AkkaConfigModule {
+        new SystemModule with StandardCountingModule
+          with StandardAuditBusModule with StandardAuditCompanionModule
+          with AkkaConfigModule {
           override lazy val actorSystem: ActorSystem = _system
           override lazy val countingService = new TestCountingService()(this)
         }
@@ -49,7 +50,7 @@ class CountingActorSpec(_system: ActorSystem) extends TestKit(_system)
     "send messages to its audit companion" in {
       val auditCompanionProbe: TestProbe = new TestProbe(_system)
       val testConfig: SystemModule =
-        new SystemModule with StandardCountingModule with StandardAuditModule with AkkaConfigModule {
+        new SystemModule with StandardCountingModule with StandardAuditBusModule with StandardAuditCompanionModule with AkkaConfigModule {
           override lazy val actorSystem: ActorSystem = _system
           override lazy val auditCompanion = auditCompanionProbe.ref
         }


### PR DESCRIPTION
Split AuditModule into AuditBusModule and AuditCompanionModule to make injection clearer and avoid stack overflow bug potential. Dick, do you like this change or am I missing something? 
